### PR TITLE
refactor: move Emote to view layer, don't attach to model

### DIFF
--- a/src/story/ant/emote.rs
+++ b/src/story/ant/emote.rs
@@ -1,3 +1,4 @@
+// TODO: move this to an area that is clearly UI-only
 /// Ants might emote from time to time. This results in showing an emoji above their head.
 use bevy::prelude::*;
 
@@ -9,7 +10,7 @@ pub enum EmoteType {
 
 #[derive(Component, Debug, PartialEq, Copy, Clone)]
 pub struct Emote {
-    pub emote_type: EmoteType,
+    emote_type: EmoteType,
     value: f32,
     max: f32,
 }
@@ -21,6 +22,10 @@ impl Emote {
             value: 0.0,
             max: 100.0,
         }
+    }
+
+    pub fn emote_type(&self) -> EmoteType {
+        self.emote_type
     }
 
     pub fn max(&self) -> f32 {

--- a/src/story/ant/hunger.rs
+++ b/src/story/ant/hunger.rs
@@ -1,8 +1,6 @@
 use super::{
-    commands::AntCommandsExt,
-    digestion::Digestion,
-    emote::{Emote, EmoteType},
-    AntInventory, AntOrientation, AntRole, Dead, Initiative,
+    commands::AntCommandsExt, digestion::Digestion, AntAteFoodEvent, AntInventory, AntOrientation,
+    AntRole, Dead, Initiative,
 };
 use crate::story::{
     common::position::Position,
@@ -92,6 +90,7 @@ pub fn ants_hunger_act(
     elements_query: Query<&Element>,
     mut commands: Commands,
     nest_query: Query<&Grid, With<Nest>>,
+    mut ant_ate_food_event_writer: EventWriter<AntAteFoodEvent>,
 ) {
     let grid = nest_query.single();
 
@@ -127,9 +126,7 @@ pub fn ants_hunger_act(
                     digestion.increment(-0.20);
                     initiative.consume();
 
-                    commands
-                        .entity(ant_entity)
-                        .insert(Emote::new(EmoteType::FoodLove));
+                    ant_ate_food_event_writer.send(AntAteFoodEvent(ant_entity));
                 }
             }
         }
@@ -158,7 +155,7 @@ pub fn ants_regurgitate(
         ),
         With<AtNest>,
     >,
-    mut commands: Commands,
+    mut ant_ate_food_event_writer: EventWriter<AntAteFoodEvent>,
 ) {
     let peckish_ants = ants_hunger_query
         .iter()
@@ -242,8 +239,6 @@ pub fn ants_regurgitate(
         ant_initiative.consume();
         other_ant_initiative.consume();
 
-        commands
-            .entity(ant_entity)
-            .insert(Emote::new(EmoteType::FoodLove));
+        ant_ate_food_event_writer.send(AntAteFoodEvent(ant_entity));
     }
 }

--- a/src/story/ant/mod.rs
+++ b/src/story/ant/mod.rs
@@ -9,7 +9,11 @@ use self::{
     name_list::get_random_name, sleep::Asleep, tunneling::Tunneling,
 };
 
-use super::{common::{Zone, ui::ModelViewEntityMap}, element::Element, nest_simulation::nest::AtNest};
+use super::{
+    common::{ui::ModelViewEntityMap, Zone},
+    element::Element,
+    nest_simulation::nest::AtNest,
+};
 use bevy::{
     ecs::{
         entity::{EntityMapper, MapEntities},
@@ -109,6 +113,9 @@ impl MapEntities for AntInventory {
         }
     }
 }
+
+#[derive(Event, PartialEq, Copy, Clone, Debug)]
+pub struct AntAteFoodEvent(Entity);
 
 #[derive(Component, Debug, PartialEq, Copy, Clone, Serialize, Deserialize, Reflect, Default)]
 #[reflect(Component)]

--- a/src/story/ant/sleep.rs
+++ b/src/story/ant/sleep.rs
@@ -1,23 +1,24 @@
 use bevy::prelude::*;
-use bevy_turborand::{DelegatedRng, GlobalRng};
+use bevy_turborand::GlobalRng;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    settings::Settings,
-    story::{
-        ant::emote::EmoteType, common::position::Position, nest_simulation::nest::{Nest, AtNest},
-        story_time::StoryTime,
-    },
+use crate::story::{
+    common::position::Position,
+    nest_simulation::nest::{AtNest, Nest},
+    story_time::StoryTime,
 };
 
-use super::{emote::Emote, AntInventory, AntOrientation, Initiative};
+use super::{AntInventory, AntOrientation, Initiative};
 
 #[derive(Component, Debug, PartialEq, Copy, Clone, Serialize, Deserialize, Reflect, Default)]
 #[reflect(Component)]
 pub struct Asleep;
 
 pub fn ants_sleep(
-    ants_query: Query<(Entity, &Position, &AntOrientation, &AntInventory), (With<Initiative>, With<AtNest>)>,
+    ants_query: Query<
+        (Entity, &Position, &AntOrientation, &AntInventory),
+        (With<Initiative>, With<AtNest>),
+    >,
     mut commands: Commands,
     nest_query: Query<&Nest>,
     story_time: Res<StoryTime>,
@@ -41,22 +42,6 @@ pub fn ants_sleep(
     }
 }
 
-// TODO: This actually seems like a view-only concern
-pub fn ants_sleep_emote(
-    ants_query: Query<Entity, (With<Asleep>, Without<Emote>, With<AtNest>)>,
-    mut commands: Commands,
-    mut rng: ResMut<GlobalRng>,
-    settings: Res<Settings>,
-) {
-    for ant_entity in ants_query.iter() {
-        if rng.f32() < settings.probabilities.sleep_emote {
-            commands
-                .entity(ant_entity)
-                .insert(Emote::new(EmoteType::Asleep));
-        }
-    }
-}
-
 pub fn ants_wake(
     ants_query: Query<Entity, (With<Asleep>, With<AtNest>)>,
     mut commands: Commands,
@@ -71,8 +56,6 @@ pub fn ants_wake(
         commands
             .entity(ant_entity)
             .remove::<Asleep>()
-            .insert(Initiative::new(&mut rng.reborrow()))
-            // Probably not great architecture but clear the Asleep emote when waking
-            .remove::<Emote>();
+            .insert(Initiative::new(&mut rng.reborrow()));
     }
 }

--- a/src/story/ant/ui.rs
+++ b/src/story/ant/ui.rs
@@ -2,7 +2,8 @@ use std::ops::Add;
 
 use super::{
     emote::{Emote, EmoteType},
-    Ant, AntColor, AntInventory, AntName, AntOrientation, AntRole, Dead,
+    sleep::Asleep,
+    Ant, AntAteFoodEvent, AntColor, AntInventory, AntName, AntOrientation, AntRole, Dead,
 };
 use crate::{
     settings::Settings,
@@ -21,6 +22,7 @@ use crate::{
     },
 };
 use bevy::{prelude::*, utils::HashSet};
+use bevy_turborand::{DelegatedRng, GlobalRng};
 
 #[derive(Component, Copy, Clone)]
 pub struct TranslationOffset(pub Vec3);
@@ -502,7 +504,6 @@ pub fn on_removed_emote(
     mut removed: RemovedComponents<Emote>,
     emote_view_query: Query<(Entity, &EmoteSprite)>,
     mut commands: Commands,
-    model_view_entity_map: Res<ModelViewEntityMap>,
     nest_query: Query<&Grid, With<Nest>>,
     visible_grid: Res<VisibleGrid>,
 ) {
@@ -515,11 +516,7 @@ pub fn on_removed_emote(
         return;
     }
 
-    let emoting_model_entities = &mut removed.read().collect::<HashSet<_>>();
-    let emoting_view_entities = emoting_model_entities
-        .iter()
-        .filter_map(|model_entity| model_view_entity_map.0.get(model_entity))
-        .collect::<HashSet<_>>();
+    let emoting_view_entities = &mut removed.read().collect::<HashSet<_>>();
 
     for (emote_view_entity, emote_sprite) in emote_view_query.iter() {
         if emoting_view_entities.contains(&emote_sprite.parent_entity) {
@@ -529,19 +526,18 @@ pub fn on_removed_emote(
     }
 }
 
-// TODO: there's weird view/model implications here. Emote isn't persisted, but is stored on Model entity currently.
 pub fn on_tick_emote(
-    mut ant_model_query: Query<(Entity, &mut Emote), With<AtNest>>,
+    mut ant_view_query: Query<(Entity, &mut Emote), With<AtNest>>,
     mut commands: Commands,
     settings: Res<Settings>,
 ) {
-    for (ant_model_entity, mut emote) in ant_model_query.iter_mut() {
+    for (ant_view_entity, mut emote) in ant_view_query.iter_mut() {
         let rate_of_emote_expire =
             emote.max() / (settings.emote_duration * DEFAULT_TICKS_PER_SECOND) as f32;
         emote.tick(rate_of_emote_expire);
 
         if emote.is_expired() {
-            commands.entity(ant_model_entity).remove::<Emote>();
+            commands.entity(ant_view_entity).remove::<Emote>();
         }
     }
 }
@@ -552,12 +548,10 @@ pub struct EmoteSprite {
 }
 
 pub fn on_added_ant_emote(
-    ant_model_query: Query<(Entity, &Emote), Added<Emote>>,
-    ant_view_query: Query<&Children>,
+    ant_view_query: Query<(Entity, &Emote, &Children), Added<Emote>>,
     ant_sprite_view_query: Query<&AntSprite>,
     mut commands: Commands,
     asset_server: Res<AssetServer>,
-    model_view_entity_map: Res<ModelViewEntityMap>,
     nest_query: Query<&Grid, With<Nest>>,
     visible_grid: Res<VisibleGrid>,
 ) {
@@ -570,38 +564,87 @@ pub fn on_added_ant_emote(
         return;
     }
 
-    for (ant_model_entity, emote) in ant_model_query.iter() {
-        if let Some(&ant_view_entity) = model_view_entity_map.0.get(&ant_model_entity) {
-            if let Ok(children) = ant_view_query.get(ant_view_entity) {
-                if let Some(ant_sprite_view_entity) = children
-                    .iter()
-                    .find(|&&child| ant_sprite_view_query.get(child).is_ok())
-                {
-                    commands
-                        .entity(*ant_sprite_view_entity)
-                        .with_children(|parent| {
-                            let texture = match emote.emote_type {
-                                EmoteType::Asleep => asset_server.load("images/zzz.png"),
-                                EmoteType::FoodLove => asset_server.load("images/foodlove.png"),
-                            };
+    for (ant_view_entity, emote, children) in ant_view_query.iter() {
+        if let Some(ant_sprite_view_entity) = children
+            .iter()
+            .find(|&&child| ant_sprite_view_query.get(child).is_ok())
+        {
+            commands
+                .entity(*ant_sprite_view_entity)
+                .with_children(|parent| {
+                    let texture = match emote.emote_type() {
+                        EmoteType::Asleep => asset_server.load("images/zzz.png"),
+                        EmoteType::FoodLove => asset_server.load("images/foodlove.png"),
+                    };
 
-                            parent.spawn((
-                                EmoteSprite {
-                                    parent_entity: ant_view_entity,
-                                },
-                                SpriteBundle {
-                                    transform: Transform::from_xyz(0.75, 1.0, 1.0),
-                                    sprite: Sprite {
-                                        custom_size: Some(Vec2::splat(1.0)),
-                                        ..default()
-                                    },
-                                    texture,
-                                    ..default()
-                                },
-                            ));
-                        });
-                }
-            }
+                    parent.spawn((
+                        EmoteSprite {
+                            parent_entity: ant_view_entity,
+                        },
+                        SpriteBundle {
+                            transform: Transform::from_xyz(0.75, 1.0, 1.0),
+                            sprite: Sprite {
+                                custom_size: Some(Vec2::splat(1.0)),
+                                ..default()
+                            },
+                            texture,
+                            ..default()
+                        },
+                    ));
+                });
+        }
+    }
+}
+
+pub fn on_ant_ate_food(
+    mut ant_action_events: EventReader<AntAteFoodEvent>,
+    mut commands: Commands,
+    model_view_entity_map: Res<ModelViewEntityMap>,
+) {
+    for AntAteFoodEvent(ant_model_entity) in ant_action_events.read() {
+        let ant_view_entity = match model_view_entity_map.0.get(ant_model_entity) {
+            Some(ant_view_entity) => *ant_view_entity,
+            None => continue,
+        };
+
+        commands
+            .entity(ant_view_entity)
+            .insert(Emote::new(EmoteType::FoodLove));
+    }
+}
+
+pub fn ants_sleep_emote(
+    ants_query: Query<Entity, (With<Asleep>, With<AtNest>)>,
+    mut commands: Commands,
+    mut rng: ResMut<GlobalRng>,
+    settings: Res<Settings>,
+    model_view_entity_map: Res<ModelViewEntityMap>,
+) {
+    for ant_model_entity in ants_query.iter() {
+        if rng.f32() < settings.probabilities.sleep_emote {
+            let ant_view_entity = match model_view_entity_map.0.get(&ant_model_entity) {
+                Some(ant_view_entity) => *ant_view_entity,
+                None => continue,
+            };
+
+            commands
+                .entity(ant_view_entity)
+                .insert(Emote::new(EmoteType::Asleep));
+        }
+    }
+}
+
+pub fn on_ant_wake_up(
+    // TODO: Maybe this should be event-driven and have an AntWakeUpEvent instead? That way this won't run when ants are getting destroyed.
+    mut removed: RemovedComponents<Asleep>,
+    model_view_entity_map: Res<ModelViewEntityMap>,
+    mut commands: Commands,
+) {
+    for ant_model_entity in removed.read() {
+        if let Some(view_entity) = model_view_entity_map.0.get(&ant_model_entity) {
+            // TODO: This code isn't great because it's presumptuous. There's not a guarantee that sleeping ant was showing an emote
+            // and, if it is showing an emote, maybe that emote isn't the Asleep emote. Still, this assumption holds for now.
+            commands.entity(*view_entity).remove::<Emote>();
         }
     }
 }

--- a/src/story/nest_simulation/mod.rs
+++ b/src/story/nest_simulation/mod.rs
@@ -74,7 +74,7 @@ use self::{
 };
 
 use super::{
-    ant::{nesting::ants_nesting_start, ui::{on_ant_ate_food, ants_sleep_emote, on_ant_wake_up}},
+    ant::{nesting::ants_nesting_start, ui::{on_ant_ate_food, ants_sleep_emote, on_ant_wake_up}, AntAteFoodEvent},
     common::{setup_common, teardown_common, ui::on_update_selected_position},
     crater_simulation::crater::{register_crater, ui::on_crater_removed_visible_grid},
     element::{
@@ -102,6 +102,9 @@ impl Plugin for NestSimulationPlugin {
         // TODO: timing of this is weird/important, want to have schedule setup early
         app.init_resource::<SimulationTime>();
         app.add_systems(PreStartup, insert_simulation_schedule);
+
+        // TODO: This isn't a good home for this. Need to create a view-specific layer and initialize it there.
+        app.init_resource::<Events<AntAteFoodEvent>>();
 
         app.add_systems(
             OnEnter(AppState::BeginSetup),

--- a/src/story/nest_simulation/mod.rs
+++ b/src/story/nest_simulation/mod.rs
@@ -30,7 +30,7 @@ use crate::{
             nest_expansion::ants_nest_expansion,
             nesting::{ants_nesting_action, ants_nesting_movement, register_nesting},
             register_ant,
-            sleep::{ants_sleep, ants_sleep_emote, ants_wake},
+            sleep::{ants_sleep, ants_wake},
             teardown_ant,
             tunneling::{
                 ants_add_tunnel_pheromone, ants_fade_tunnel_pheromone,
@@ -74,7 +74,7 @@ use self::{
 };
 
 use super::{
-    ant::nesting::ants_nesting_start,
+    ant::{nesting::ants_nesting_start, ui::{on_ant_ate_food, ants_sleep_emote, on_ant_wake_up}},
     common::{setup_common, teardown_common, ui::on_update_selected_position},
     crater_simulation::crater::{register_crater, ui::on_crater_removed_visible_grid},
     element::{
@@ -219,15 +219,6 @@ impl Plugin for NestSimulationPlugin {
                         (ants_birthing, apply_deferred).chain(),
                         (ants_sleep, ants_wake, apply_deferred).chain(),
                         (
-                            ants_sleep_emote.run_if(
-                                resource_exists::<StoryTime>()
-                                    .and_then(tick_count_elapsed(DEFAULT_TICKS_PER_SECOND)),
-                            ),
-                            on_tick_emote,
-                            apply_deferred,
-                        )
-                            .chain(),
-                        (
                             // Apply Nesting Logic
                             ants_nesting_start,
                             ants_nesting_movement,
@@ -332,6 +323,15 @@ impl Plugin for NestSimulationPlugin {
                     on_update_ant_orientation,
                     on_update_ant_color,
                     on_update_ant_inventory,
+                    on_ant_ate_food,
+                    // TODO: naming inconsistencies, but probably want to go more this direction rather than away.
+                    ants_sleep_emote.run_if(
+                        // TODO: this feels hacky? trying to rate limit how often checks for sleeping emoting occurs.
+                        resource_exists::<StoryTime>()
+                            .and_then(tick_count_elapsed(DEFAULT_TICKS_PER_SECOND)),
+                    ),
+                    on_ant_wake_up,
+                    on_tick_emote,
                     on_update_element,
                     on_update_pheromone_visibility,
                 ),

--- a/src/story/nest_simulation/nest/mod.rs
+++ b/src/story/nest_simulation/nest/mod.rs
@@ -92,9 +92,6 @@ pub fn setup_nest_ants(
     mut rng: ResMut<GlobalRng>,
     mut commands: Commands,
 ) {
-    // TODO: This isn't necessarily related to nest ants -- just ants in general.
-    commands.init_resource::<Events<AntAteFoodEvent>>();
-
     let nest = nest_query.single();
     let mut rng = rng.reborrow();
 

--- a/src/story/nest_simulation/nest/mod.rs
+++ b/src/story/nest_simulation/nest/mod.rs
@@ -9,8 +9,8 @@ use crate::{
     settings::Settings,
     story::{
         ant::{
-            digestion::Digestion, hunger::Hunger, Angle, AntBundle, AntColor, AntInventory,
-            AntName, AntOrientation, AntRole, Facing, Initiative,
+            digestion::Digestion, hunger::Hunger, Angle, AntAteFoodEvent, AntBundle, AntColor,
+            AntInventory, AntName, AntOrientation, AntRole, Facing, Initiative,
         },
         common::{position::Position, Zone},
         element::{Element, ElementBundle},
@@ -92,6 +92,9 @@ pub fn setup_nest_ants(
     mut rng: ResMut<GlobalRng>,
     mut commands: Commands,
 ) {
+    // TODO: This isn't necessarily related to nest ants -- just ants in general.
+    commands.init_resource::<Events<AntAteFoodEvent>>();
+
     let nest = nest_query.single();
     let mut rng = rng.reborrow();
 


### PR DESCRIPTION
This PR moves the `Emote` component to the view layer. Previously, Emote was attached to the model entity, but now it is attached to the view entity. There shouldn't be any functional differences. 

Testing:

* I ran sim for a full in-game day and confirmed that ants went to sleep, showed ZzZ emote, and that the emote became hidden periodically and then showed itself again.

* I ran a slightly modified version of the sim where ants spawn hungry enough to eat food and then tried feeding them food. Confirmed emote appeared and hid appropriately.

* Refreshed page and confirmed existing colony worked as well as original.