### PR TITLE
Refactor: introduce NestRenderingPlugin and move `ui.rs` declarations into it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,8 @@ use main_menu::update_main_menu;
 use save::CompressedWebStorageBackend;
 use story::{
     camera::CameraPlugin, crater_simulation::CraterSimulationPlugin, grid::VisibleGridState,
-    nest_simulation::NestSimulationPlugin, story_time::StoryPlaybackState, ui::StoryUIPlugin,
+    nest_rendering::NestRenderingPlugin, nest_simulation::NestSimulationPlugin,
+    story_time::StoryPlaybackState, ui::StoryUIPlugin,
 };
 
 pub struct SymbiantsPlugin;
@@ -69,6 +70,7 @@ impl Plugin for SymbiantsPlugin {
             CoreUIPlugin,
             StoryUIPlugin,
             NestSimulationPlugin,
+            NestRenderingPlugin,
             CraterSimulationPlugin,
         ));
 

--- a/src/story/ant/mod.rs
+++ b/src/story/ant/mod.rs
@@ -9,11 +9,7 @@ use self::{
     name_list::get_random_name, sleep::Asleep, tunneling::Tunneling,
 };
 
-use super::{
-    common::{ui::ModelViewEntityMap, Zone},
-    element::Element,
-    nest_simulation::nest::AtNest,
-};
+use super::{common::Zone, element::Element, nest_simulation::nest::AtNest};
 use bevy::{
     ecs::{
         entity::{EntityMapper, MapEntities},
@@ -36,7 +32,6 @@ pub mod nest_expansion;
 pub mod nesting;
 pub mod sleep;
 pub mod tunneling;
-pub mod ui;
 pub mod walk;
 
 #[derive(Bundle)]
@@ -115,7 +110,7 @@ impl MapEntities for AntInventory {
 }
 
 #[derive(Event, PartialEq, Copy, Clone, Debug)]
-pub struct AntAteFoodEvent(Entity);
+pub struct AntAteFoodEvent(pub Entity);
 
 #[derive(Component, Debug, PartialEq, Copy, Clone, Serialize, Deserialize, Reflect, Default)]
 #[reflect(Component)]
@@ -450,20 +445,9 @@ pub fn register_ant(app_type_registry: ResMut<AppTypeRegistry>) {
     app_type_registry.write().register::<Chambering>();
 }
 
-// TODO: It's weird that this handles both view and model cleanup.
-// Can't easily rely on UI to handle view cleanup because it only runs when AppState is TellStory.
-// If its changed to run during Cleanup then resources etc might be missing.
-pub fn teardown_ant(
-    ant_model_query: Query<Entity, With<Ant>>,
-    mut commands: Commands,
-    mut model_view_entity_map: ResMut<ModelViewEntityMap>,
-) {
+pub fn teardown_ant(ant_model_query: Query<Entity, With<Ant>>, mut commands: Commands) {
+    info!("teardown_ant models");
     for ant_model_entity in ant_model_query.iter() {
-        if let Some(&ant_view_entity) = model_view_entity_map.0.get(&ant_model_entity) {
-            commands.entity(ant_view_entity).despawn_recursive();
-            model_view_entity_map.0.remove(&ant_model_entity);
-        }
-
         commands.entity(ant_model_entity).despawn();
     }
 }

--- a/src/story/ant/mod.rs
+++ b/src/story/ant/mod.rs
@@ -446,7 +446,6 @@ pub fn register_ant(app_type_registry: ResMut<AppTypeRegistry>) {
 }
 
 pub fn teardown_ant(ant_model_query: Query<Entity, With<Ant>>, mut commands: Commands) {
-    info!("teardown_ant models");
     for ant_model_entity in ant_model_query.iter() {
         commands.entity(ant_model_entity).despawn();
     }

--- a/src/story/camera/mod.rs
+++ b/src/story/camera/mod.rs
@@ -6,7 +6,7 @@ use bevy::{
 
 use self::pancam::{PanCam, PanCamPlugin};
 
-use super::common::ui::VisibleGrid;
+use super::nest_rendering::common::VisibleGrid;
 
 mod pancam;
 

--- a/src/story/common/mod.rs
+++ b/src/story/common/mod.rs
@@ -1,12 +1,8 @@
 use bevy::prelude::*;
 
-use self::{
-    position::Position,
-    ui::{ModelViewEntityMap, SelectedEntity, SelectionSprite, VisibleGrid},
-};
+use self::position::Position;
 
 pub mod position;
-pub mod ui;
 
 // This maps to AtNest or AtCrater
 /// Use an empty trait to mark Nest and Crater zones to ensure strong type safety in generic systems.
@@ -16,33 +12,4 @@ pub fn register_common(app_type_registry: ResMut<AppTypeRegistry>) {
     app_type_registry.write().register::<Entity>();
     app_type_registry.write().register::<Option<Entity>>();
     app_type_registry.write().register::<Position>();
-}
-
-pub fn setup_common(mut commands: Commands) {
-    commands.init_resource::<ModelViewEntityMap>();
-    commands.init_resource::<SelectedEntity>();
-    commands.init_resource::<VisibleGrid>();
-}
-
-pub fn teardown_common(
-    selection_sprite_query: Query<Entity, With<SelectionSprite>>,
-    mut commands: Commands,
-    model_view_entity_map: Res<ModelViewEntityMap>
-) {
-    if let Ok(selection_sprite_entity) = selection_sprite_query.get_single() {
-        commands.entity(selection_sprite_entity).despawn();
-    }
-
-    commands.remove_resource::<SelectedEntity>();
-    commands.remove_resource::<VisibleGrid>();
-
-    if model_view_entity_map.0.len() > 0 {
-        panic!(
-            "ModelViewEntityMap has {} entries remaining after cleanup",
-            model_view_entity_map.0.len()
-        );
-    }
-
-    // TODO: removing this causes issues because camera Update runs expecting the resource to exist.
-    //commands.remove_resource::<ModelViewEntityMap>();
 }

--- a/src/story/crater_simulation/crater/mod.rs
+++ b/src/story/crater_simulation/crater/mod.rs
@@ -1,5 +1,3 @@
-pub mod ui;
-
 use bevy::prelude::*;
 use bevy_turborand::GlobalRng;
 use serde::{Deserialize, Serialize};

--- a/src/story/grid/mod.rs
+++ b/src/story/grid/mod.rs
@@ -7,6 +7,7 @@ use crate::story::common::position::Position;
 
 use self::elements_cache::ElementsCache;
 
+// TODO: I think this is a view concern...?
 // TODO: prob don't want both component (VisibleGrid) and VisibleGridState? idk
 #[derive(States, Default, Hash, Clone, Copy, Eq, PartialEq, Debug)]
 pub enum VisibleGridState {

--- a/src/story/mod.rs
+++ b/src/story/mod.rs
@@ -5,6 +5,7 @@ pub mod crater_simulation;
 pub mod element;
 pub mod grid;
 pub mod nest_simulation;
+pub mod nest_rendering;
 pub mod pheromone;
 pub mod pointer;
 pub mod simulation_timestep;

--- a/src/story/nest_rendering/ant/mod.rs
+++ b/src/story/nest_rendering/ant/mod.rs
@@ -1,22 +1,20 @@
 use std::ops::Add;
 
-use super::{
-    emote::{Emote, EmoteType},
-    sleep::Asleep,
-    Ant, AntAteFoodEvent, AntColor, AntInventory, AntName, AntOrientation, AntRole, Dead,
-};
 use crate::{
     settings::Settings,
     story::{
-        common::{
-            position::Position,
-            ui::{ModelViewEntityMap, VisibleGrid},
+        ant::{
+            emote::{Emote, EmoteType},
+            sleep::Asleep,
+            Ant, AntAteFoodEvent, AntColor, AntInventory, AntName, AntOrientation, AntRole, Dead,
         },
-        element::{
-            ui::{get_element_index, ElementExposure, ElementTextureAtlasHandle},
-            Element,
-        },
+        common::position::Position,
+        element::{Element, ElementExposure},
         grid::Grid,
+        nest_rendering::{
+            common::{ModelViewEntityMap, VisibleGrid},
+            element::{get_element_index, ElementTextureAtlasHandle},
+        },
         nest_simulation::nest::{AtNest, Nest},
         story_time::DEFAULT_TICKS_PER_SECOND,
     },
@@ -645,6 +643,19 @@ pub fn on_ant_wake_up(
             // TODO: This code isn't great because it's presumptuous. There's not a guarantee that sleeping ant was showing an emote
             // and, if it is showing an emote, maybe that emote isn't the Asleep emote. Still, this assumption holds for now.
             commands.entity(*view_entity).remove::<Emote>();
+        }
+    }
+}
+
+pub fn teardown_ant(
+    ant_model_query: Query<Entity, With<Ant>>,
+    mut commands: Commands,
+    mut model_view_entity_map: ResMut<ModelViewEntityMap>,
+) {
+    for ant_model_entity in ant_model_query.iter() {
+        if let Some(&ant_view_entity) = model_view_entity_map.0.get(&ant_model_entity) {
+            commands.entity(ant_view_entity).despawn_recursive();
+            model_view_entity_map.0.remove(&ant_model_entity);
         }
     }
 }

--- a/src/story/nest_rendering/common/mod.rs
+++ b/src/story/nest_rendering/common/mod.rs
@@ -1,8 +1,6 @@
 use bevy::{prelude::*, utils::HashMap};
 
-use crate::story::{grid::Grid, nest_simulation::nest::Nest};
-
-use super::position::Position;
+use crate::story::{grid::Grid, nest_simulation::nest::Nest, common::position::Position};
 
 // TODO: This probably isn't a great home for this. The intent is to mark which of the grid (crater vs nest) is active/shown.
 #[derive(Resource, Default)]
@@ -111,4 +109,25 @@ pub fn on_update_selected_position(
     world_position.z = 3.0;
 
     transform.translation = world_position;
+}
+
+pub fn setup_common(mut commands: Commands) {
+    commands.init_resource::<ModelViewEntityMap>();
+    commands.init_resource::<SelectedEntity>();
+    commands.init_resource::<VisibleGrid>();
+}
+
+pub fn teardown_common(
+    selection_sprite_query: Query<Entity, With<SelectionSprite>>,
+    mut commands: Commands,
+) {
+    if let Ok(selection_sprite_entity) = selection_sprite_query.get_single() {
+        commands.entity(selection_sprite_entity).despawn();
+    }
+
+    commands.remove_resource::<SelectedEntity>();
+    commands.remove_resource::<VisibleGrid>();
+
+    // TODO: removing this causes issues because camera Update runs expecting the resource to exist.
+    //commands.remove_resource::<ModelViewEntityMap>();
 }

--- a/src/story/nest_rendering/mod.rs
+++ b/src/story/nest_rendering/mod.rs
@@ -1,0 +1,167 @@
+mod ant;
+// TODO: This shouldn't be common - need to move UI (non-Bevy) rendering closer to this location.
+pub mod common;
+mod crater;
+mod element;
+mod nest;
+mod pheromone;
+
+use bevy::prelude::*;
+
+use crate::app_state::AppState;
+
+use self::{
+    ant::{
+        ants_sleep_emote, on_added_ant_dead, on_added_ant_emote, on_ant_ate_food, on_ant_wake_up,
+        on_despawn_ant, on_removed_emote, on_spawn_ant, on_tick_emote, on_update_ant_color,
+        on_update_ant_inventory, on_update_ant_orientation, on_update_ant_position, rerender_ants,
+        teardown_ant,
+    },
+    common::{
+        on_update_selected, on_update_selected_position, setup_common, teardown_common,
+        ModelViewEntityMap,
+    },
+    crater::on_crater_removed_visible_grid,
+    element::{
+        check_element_sprite_sheet_loaded, on_despawn_element, on_update_element,
+        rerender_elements, start_load_element_sprite_sheet, teardown_element,
+    },
+    nest::{on_nest_removed_visible_grid, on_spawn_nest},
+    pheromone::{
+        on_despawn_pheromone, on_spawn_pheromone, on_update_pheromone_visibility,
+        rerender_pheromones, teardown_pheromone,
+    },
+};
+
+use super::{
+    grid::VisibleGridState,
+    story_time::{teardown_story_time, StoryPlaybackState, StoryTime, DEFAULT_TICKS_PER_SECOND},
+};
+
+pub struct NestRenderingPlugin;
+
+impl Plugin for NestRenderingPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            OnEnter(AppState::BeginSetup),
+            start_load_element_sprite_sheet,
+        );
+
+        app.add_systems(
+            Update,
+            check_element_sprite_sheet_loaded.run_if(in_state(AppState::BeginSetup)),
+        );
+
+        app.add_systems(
+            OnEnter(AppState::FinishSetup),
+            (
+                // TODO: Do I need to ensure this runs after other stuff?
+                (setup_common, apply_deferred).chain(),
+            )
+                .chain(),
+        );
+
+        // Declare all rendering systems within Update. No need to chain systems because all rendering systems
+        // depend on simulation state which is updated within FixedUpdate.
+        // IMPORTANT:
+        // RemovedComponents<T> may contain stale/duplicate information when queried within Update
+        // This occurs because the FixedUpdate schedule may run multiple times before yielding to Update
+        app.add_systems(
+            Update,
+            (
+                // TODO: This apply_deferred sucks but I'm relying on view state to reactively render
+                // and so I need this to be accurate now not next frame.
+                on_spawn_nest,
+                apply_deferred,
+                // Spawn
+                (on_spawn_ant, on_spawn_pheromone),
+                // Despawn
+                // TODO: make these generic
+                (on_despawn_ant, on_despawn_element, on_despawn_pheromone),
+                // Added
+                (on_added_ant_dead, on_added_ant_emote),
+                // Removed
+                (
+                    on_removed_emote,
+                    on_nest_removed_visible_grid,
+                    on_crater_removed_visible_grid,
+                ),
+                // Updated
+                (
+                    on_update_selected,
+                    on_update_selected_position,
+                    on_update_ant_position,
+                    on_update_ant_orientation,
+                    on_update_ant_color,
+                    on_update_ant_inventory,
+                    on_ant_ate_food,
+                    // TODO: naming inconsistencies, but probably want to go more this direction rather than away.
+                    ants_sleep_emote.run_if(
+                        // TODO: this feels hacky? trying to rate limit how often checks for sleeping emoting occurs.
+                        resource_exists::<StoryTime>()
+                            .and_then(tick_count_elapsed(DEFAULT_TICKS_PER_SECOND)),
+                    ),
+                    on_ant_wake_up,
+                    on_tick_emote,
+                    on_update_element,
+                    on_update_pheromone_visibility,
+                ),
+            )
+                .chain()
+                .run_if(
+                    in_state(AppState::TellStory)
+                        .and_then(not(in_state(StoryPlaybackState::FastForwarding))),
+                ),
+        );
+
+        app.add_systems(
+            OnExit(StoryPlaybackState::FastForwarding),
+            (rerender_ants, rerender_elements, rerender_pheromones)
+                .chain()
+                .run_if(in_state(VisibleGridState::Nest)),
+        );
+
+        app.add_systems(
+            OnEnter(VisibleGridState::Nest),
+            (rerender_ants, rerender_elements, rerender_pheromones)
+                .chain()
+                .run_if(in_state(StoryPlaybackState::Playing)),
+        );
+
+        app.add_systems(
+            OnEnter(AppState::Cleanup),
+            (
+                teardown_ant,
+                teardown_element,
+                teardown_pheromone,
+                teardown_common,
+            )
+                .before(teardown_story_time)
+                .chain(),
+        );
+
+        app.add_systems(
+            OnExit(AppState::Cleanup),
+            |model_view_entity_map: Res<ModelViewEntityMap>| {
+                if model_view_entity_map.0.len() > 0 {
+                    panic!(
+                        "ModelViewEntityMap has {} entries remaining after cleanup",
+                        model_view_entity_map.0.len()
+                    );
+                }
+            },
+        );
+    }
+}
+
+// TODO: Maybe do this according to time rather than number of ticks elapsing to keep things consistent
+fn tick_count_elapsed(ticks: isize) -> impl FnMut(Local<isize>, Res<StoryTime>) -> bool {
+    move |mut last_run_tick_count: Local<isize>, story_time: Res<StoryTime>| {
+        if *last_run_tick_count + ticks <= story_time.elapsed_ticks() {
+            *last_run_tick_count = story_time.elapsed_ticks();
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/src/story/nest_rendering/nest/mod.rs
+++ b/src/story/nest_rendering/nest/mod.rs
@@ -1,49 +1,32 @@
 use bevy::prelude::*;
 use bevy_ecs_tilemap::tiles::TileVisible;
 
-use crate::story::common::ui::{ModelViewEntityMap, VisibleGrid};
+use crate::story::nest_simulation::nest::{AtNest, Nest};
 
-use super::{AtCrater, Crater};
+use super::common::{ModelViewEntityMap, VisibleGrid};
 
-pub fn on_added_crater_visible_grid(
-    crater_query: Query<&Crater>,
-    visible_grid: Res<VisibleGrid>,
-    mut at_crater_view_query: Query<
-        (Option<&mut TileVisible>, Option<&mut Visibility>),
-        With<AtCrater>,
-    >,
+// Assume for now that when the simulation loads the user wants to see their nest, but in the future might need to make this more flexible.
+pub fn on_spawn_nest(
+    nest_query: Query<Entity, Added<Nest>>,
+    mut visible_grid: ResMut<VisibleGrid>,
 ) {
-    if !visible_grid.is_changed() {
-        return;
-    }
-
-    let visible_grid_entity = match visible_grid.0 {
-        Some(visible_grid_entity) => visible_grid_entity,
-        None => return,
+    let nest_entity = match nest_query.get_single() {
+        Ok(nest_entity) => nest_entity,
+        Err(_) => return,
     };
 
-    if !crater_query.get(visible_grid_entity).is_ok() {
-        return;
-    }
-
-    for (tile_visible, visibility) in at_crater_view_query.iter_mut() {
-        if let Some(mut tile_visibile) = tile_visible {
-            tile_visibile.0 = true;
-        } else if let Some(mut visibility) = visibility {
-            *visibility = Visibility::Visible;
-        }
-    }
+    visible_grid.0 = Some(nest_entity);
 }
 
 // TODO: sheesh this entire method sucks.
 // TODO: naming of this vs added doesn't have parity
-pub fn on_crater_removed_visible_grid(
+pub fn on_nest_removed_visible_grid(
     visible_grid: Res<VisibleGrid>,
-    crater_query: Query<&Crater>,
-    at_crater_view_query: Query<
+    nest_query: Query<&Nest>,
+    at_nest_view_query: Query<
         Entity,
         // TODO: Better way to select just views? Should I introduce a View component?
-        (With<AtCrater>, Or<(With<TileVisible>, With<Visibility>)>),
+        (With<AtNest>, Or<(With<TileVisible>, With<Visibility>)>),
     >,
     mut commands: Commands,
     mut model_view_entity_map: ResMut<ModelViewEntityMap>,
@@ -57,12 +40,12 @@ pub fn on_crater_removed_visible_grid(
     // The issue is that if there were 3+ potential visible grids then this would run more often than desired
     // because it would try to remove visibility from nest elements when changing visibility between two non-nest grids.
     if let Some(visible_grid_entity) = visible_grid.0 {
-        if crater_query.get(visible_grid_entity).is_ok() {
+        if nest_query.get(visible_grid_entity).is_ok() {
             return;
         }
     }
 
-    for entity in at_crater_view_query.iter() {
+    for entity in at_nest_view_query.iter() {
         commands.entity(entity).despawn_recursive();
         // TODO: maybe I need to update my tilemap storage etc when despawning here?
         // tile_storage.set(&tile_pos, element_view_entity);

--- a/src/story/nest_rendering/pheromone/mod.rs
+++ b/src/story/nest_rendering/pheromone/mod.rs
@@ -1,15 +1,13 @@
 use bevy::{prelude::*, utils::HashSet};
 
 use crate::story::{
-    common::{
-        position::Position,
-        ui::{ModelViewEntityMap, VisibleGrid},
-    },
+    common::position::Position,
     grid::Grid,
     nest_simulation::nest::{AtNest, Nest},
+    pheromone::{Pheromone, PheromoneStrength, PheromoneVisibility},
 };
 
-use super::{Pheromone, PheromoneStrength, PheromoneVisibility};
+use super::common::{ModelViewEntityMap, VisibleGrid};
 
 pub fn get_pheromone_sprite(
     pheromone: &Pheromone,
@@ -145,6 +143,19 @@ pub fn on_update_pheromone_visibility(
                     *visibility = pheromone_visibility.0;
                 }
             }
+        }
+    }
+}
+
+pub fn teardown_pheromone(
+    pheromone_model_query: Query<Entity, With<Pheromone>>,
+    mut commands: Commands,
+    mut model_view_entity_map: ResMut<ModelViewEntityMap>,
+) {
+    for pheromone_model_entity in pheromone_model_query.iter() {
+        if let Some(pheromone_view_entity) = model_view_entity_map.0.remove(&pheromone_model_entity)
+        {
+            commands.entity(pheromone_view_entity).despawn_recursive();
         }
     }
 }

--- a/src/story/nest_simulation/mod.rs
+++ b/src/story/nest_simulation/mod.rs
@@ -37,25 +37,19 @@ use crate::{
                 ants_remove_tunnel_pheromone, ants_tunnel_pheromone_act,
                 ants_tunnel_pheromone_move,
             },
-            ui::{
-                on_added_ant_dead, on_added_ant_emote, on_despawn_ant, on_removed_emote,
-                on_spawn_ant, on_tick_emote, on_update_ant_color, on_update_ant_inventory,
-                on_update_ant_orientation, on_update_ant_position, rerender_ants,
-            },
             walk::{ants_stabilize_footing_movement, ants_walk},
         },
-        common::{register_common, ui::on_update_selected},
-        element::{register_element, teardown_element, ui::rerender_elements},
+        common::register_common,
+        element::{register_element, teardown_element, update_element_exposure},
         pheromone::{
             pheromone_duration_tick, register_pheromone, setup_pheromone, teardown_pheromone,
-            ui::{on_spawn_pheromone, on_update_pheromone_visibility, rerender_pheromones},
         },
         pointer::external_event::process_external_event,
         pointer::{handle_pointer_tap, is_pointer_captured, setup_pointer},
         story_time::{
             pre_setup_story_time, register_story_time, set_rate_of_time, setup_story_time,
             teardown_story_time, update_story_elapsed_ticks, update_story_real_world_time,
-            update_time_scale, StoryPlaybackState, StoryTime, DEFAULT_TICKS_PER_SECOND,
+            update_time_scale, StoryPlaybackState,
         },
     },
 };
@@ -69,23 +63,13 @@ use self::{
     nest::{
         register_nest, setup_nest, setup_nest_ants, setup_nest_elements, setup_nest_grid,
         teardown_nest,
-        ui::{on_nest_removed_visible_grid, on_spawn_nest},
     },
 };
 
 use super::{
-    ant::{nesting::ants_nesting_start, ui::{on_ant_ate_food, ants_sleep_emote, on_ant_wake_up}, AntAteFoodEvent},
-    common::{setup_common, teardown_common, ui::on_update_selected_position},
-    crater_simulation::crater::{register_crater, ui::on_crater_removed_visible_grid},
-    element::{
-        denormalize_element,
-        ui::{
-            check_element_sprite_sheet_loaded, on_despawn_element, on_update_element,
-            start_load_element_sprite_sheet, update_element_exposure,
-        },
-    },
-    grid::VisibleGridState,
-    pheromone::ui::on_despawn_pheromone,
+    ant::{nesting::ants_nesting_start, AntAteFoodEvent},
+    crater_simulation::crater::register_crater,
+    element::denormalize_element,
     simulation_timestep::{run_simulation_update_schedule, SimulationTime},
 };
 
@@ -120,7 +104,6 @@ impl Plugin for NestSimulationPlugin {
                 register_pheromone,
                 register_nest,
                 register_crater,
-                start_load_element_sprite_sheet,
             )
                 .chain(),
         );
@@ -150,7 +133,6 @@ impl Plugin for NestSimulationPlugin {
                 (setup_pointer, apply_deferred).chain(),
                 (setup_pheromone, apply_deferred).chain(),
                 (setup_background, apply_deferred).chain(),
-                (setup_common, apply_deferred).chain(),
                 setup_save,
                 begin_story,
             )
@@ -177,12 +159,6 @@ impl Plugin for NestSimulationPlugin {
                     .and_then(not(in_state(StoryPlaybackState::FastForwarding))),
             ),
         );
-
-        app.add_systems(
-            Update,
-            check_element_sprite_sheet_loaded.run_if(in_state(AppState::BeginSetup)),
-        );
-
         app.init_schedule(RunSimulationUpdateLoop);
         app.add_systems(RunSimulationUpdateLoop, run_simulation_update_schedule);
 
@@ -293,78 +269,12 @@ impl Plugin for NestSimulationPlugin {
                 .chain(),
         );
 
-        // Declare all rendering systems within Update. No need to chain systems because all rendering systems
-        // depend on simulation state which is updated within FixedUpdate.
-        // IMPORTANT:
-        // RemovedComponents<T> may contain stale/duplicate information when queried within Update
-        // This occurs because the FixedUpdate schedule may run multiple times before yielding to Update
-        app.add_systems(
-            Update,
-            (
-                // TODO: This apply_deferred sucks but I'm relying on view state to reactively render
-                // and so I need this to be accurate now not next frame.
-                on_spawn_nest,
-                apply_deferred,
-                // Spawn
-                (on_spawn_ant, on_spawn_pheromone),
-                // Despawn
-                // TODO: make these generic
-                (on_despawn_ant, on_despawn_element, on_despawn_pheromone),
-                // Added
-                (on_added_ant_dead, on_added_ant_emote),
-                // Removed
-                (
-                    on_removed_emote,
-                    on_nest_removed_visible_grid,
-                    on_crater_removed_visible_grid,
-                ),
-                // Updated
-                (
-                    on_update_selected,
-                    on_update_selected_position,
-                    on_update_ant_position,
-                    on_update_ant_orientation,
-                    on_update_ant_color,
-                    on_update_ant_inventory,
-                    on_ant_ate_food,
-                    // TODO: naming inconsistencies, but probably want to go more this direction rather than away.
-                    ants_sleep_emote.run_if(
-                        // TODO: this feels hacky? trying to rate limit how often checks for sleeping emoting occurs.
-                        resource_exists::<StoryTime>()
-                            .and_then(tick_count_elapsed(DEFAULT_TICKS_PER_SECOND)),
-                    ),
-                    on_ant_wake_up,
-                    on_tick_emote,
-                    on_update_element,
-                    on_update_pheromone_visibility,
-                ),
-            )
-                .chain()
-                .run_if(
-                    in_state(AppState::TellStory)
-                        .and_then(not(in_state(StoryPlaybackState::FastForwarding))),
-                ),
-        );
-
-        app.add_systems(
-            OnExit(StoryPlaybackState::FastForwarding),
-            (rerender_ants, rerender_elements, rerender_pheromones)
-                .chain()
-                .run_if(in_state(VisibleGridState::Nest)),
-        );
-
-        app.add_systems(
-            OnEnter(VisibleGridState::Nest),
-            (rerender_ants, rerender_elements, rerender_pheromones)
-                .chain()
-                .run_if(in_state(StoryPlaybackState::Playing)),
-        );
-
         app.add_systems(
             Update,
             update_story_real_world_time.run_if(in_state(AppState::TellStory)),
         );
 
+        // TODO: View concern
         app.add_systems(
             Update,
             update_sky_background.run_if(
@@ -386,7 +296,7 @@ impl Plugin for NestSimulationPlugin {
 
         app.add_systems(
             OnEnter(AppState::Cleanup),
-            ((
+            (
                 teardown_story_time,
                 teardown_settings,
                 teardown_background,
@@ -395,24 +305,10 @@ impl Plugin for NestSimulationPlugin {
                 teardown_pheromone,
                 teardown_nest,
                 teardown_save,
-                teardown_common,
                 restart,
             )
-                .chain(),)
                 .chain(),
         );
-    }
-}
-
-// TODO: Maybe do this according to time rather than number of ticks elapsing to keep things consistent
-fn tick_count_elapsed(ticks: isize) -> impl FnMut(Local<isize>, Res<StoryTime>) -> bool {
-    move |mut last_run_tick_count: Local<isize>, story_time: Res<StoryTime>| {
-        if *last_run_tick_count + ticks <= story_time.elapsed_ticks() {
-            *last_run_tick_count = story_time.elapsed_ticks();
-            true
-        } else {
-            false
-        }
     }
 }
 

--- a/src/story/nest_simulation/nest/mod.rs
+++ b/src/story/nest_simulation/nest/mod.rs
@@ -3,14 +3,12 @@ use bevy::prelude::*;
 use bevy_turborand::{DelegatedRng, GlobalRng};
 use serde::{Deserialize, Serialize};
 
-pub mod ui;
-
 use crate::{
     settings::Settings,
     story::{
         ant::{
-            digestion::Digestion, hunger::Hunger, Angle, AntAteFoodEvent, AntBundle, AntColor,
-            AntInventory, AntName, AntOrientation, AntRole, Facing, Initiative,
+            digestion::Digestion, hunger::Hunger, Angle, AntBundle, AntColor, AntInventory,
+            AntName, AntOrientation, AntRole, Facing, Initiative,
         },
         common::{position::Position, Zone},
         element::{Element, ElementBundle},

--- a/src/story/pheromone/mod.rs
+++ b/src/story/pheromone/mod.rs
@@ -9,10 +9,9 @@ use crate::story::{
 
 use self::commands::PheromoneCommandsExt;
 
-use super::{common::ui::ModelViewEntityMap, nest_simulation::nest::AtNest};
+use super::{nest_rendering::common::ModelViewEntityMap, nest_simulation::nest::AtNest};
 
 pub mod commands;
-pub mod ui;
 
 #[derive(Component, Debug, PartialEq, Copy, Clone, Serialize, Deserialize, Reflect, Default)]
 #[reflect(Component)]

--- a/src/story/pointer/external_event.rs
+++ b/src/story/pointer/external_event.rs
@@ -1,8 +1,9 @@
 use crate::story::{
     ant::commands::AntCommandsExt,
-    common::{position::Position, ui::{SelectedEntity, VisibleGrid}},
+    common::position::Position,
     crater_simulation::crater::Crater,
     grid::{Grid, VisibleGridState},
+    nest_rendering::common::{SelectedEntity, VisibleGrid},
     nest_simulation::nest::{AtNest, Nest},
 };
 

--- a/src/story/pointer/mod.rs
+++ b/src/story/pointer/mod.rs
@@ -7,7 +7,7 @@ use crate::story::{
     camera::MainCamera, common::position::Position, grid::Grid, ui::action_menu::PointerAction,
 };
 
-use super::common::ui::VisibleGrid;
+use super::nest_rendering::common::VisibleGrid;
 
 #[derive(Event, PartialEq, Copy, Clone, Debug)]
 pub enum ExternalSimulationEvent {

--- a/src/story/ui/action_menu.rs
+++ b/src/story/ui/action_menu.rs
@@ -4,8 +4,8 @@ use bevy::{prelude::*, window::PrimaryWindow};
 use bevy_egui::{egui, EguiContexts};
 
 use crate::settings::Settings;
-use crate::story::common::ui::VisibleGrid;
 use crate::story::crater_simulation::crater::Crater;
+use crate::story::nest_rendering::common::VisibleGrid;
 use crate::story::nest_simulation::nest::Nest;
 use crate::story::pointer::ExternalSimulationEvent;
 use crate::story::story_time::StoryTime;

--- a/src/story/ui/selection_menu.rs
+++ b/src/story/ui/selection_menu.rs
@@ -5,8 +5,9 @@ use crate::story::{
     ant::{
         birthing::Birthing, hunger::Hunger, sleep::Asleep, AntInventory, AntName, AntRole, Dead,
     },
-    common::{position::Position, ui::SelectedEntity},
+    common::position::Position,
     element::Element,
+    nest_rendering::common::SelectedEntity,
     pheromone::{Pheromone, PheromoneStrength},
 };
 


### PR DESCRIPTION
This is a first pass at moving UI elements into a dedicated plugin. There's still a bit more work to do, but I think this PR is large enough to warrant merging as-is. The background sky/tunnel rendering wasn't moved into here because the view/model separation isn't as clean there (for example `Position` is stored on the view entity still). Also, the egui ui isn't in its own spot.

Additionally, I haven't moved all the model stuff into their own plugin. So, that'll need to happen here soon.