### PR TITLE
fix: move CompressedWebStorageBackend into save_web

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@ use bevy_save::SavePlugin;
 use bevy_turborand::prelude::*;
 use core_ui::CoreUIPlugin;
 use main_menu::update_main_menu;
-use save::CompressedWebStorageBackend;
 use story::{
     camera::CameraPlugin, crater_simulation::CraterSimulationPlugin, grid::VisibleGridState,
     nest_rendering::NestRenderingPlugin, nest_simulation::NestSimulationPlugin,
@@ -34,10 +33,7 @@ impl Plugin for SymbiantsPlugin {
         app.insert_resource(Msaa::Off);
 
         app.init_resource::<GlobalRng>();
-
-        // TODO: better spot for this?
-        app.init_resource::<CompressedWebStorageBackend>();
-
+        
         app.add_state::<AppState>();
         // TODO: call this in setup_story_time?
         app.add_state::<StoryPlaybackState>();

--- a/src/save/save_os.rs
+++ b/src/save/save_os.rs
@@ -14,3 +14,5 @@ pub fn load(_world: &mut World) -> bool {
 }
 
 pub fn initialize_save_resources() {}
+
+pub fn remove_save_resources() {}

--- a/src/save/save_os.rs
+++ b/src/save/save_os.rs
@@ -3,10 +3,14 @@ use bevy::prelude::*;
 
 pub fn save() {}
 
-pub fn setup_save() {}
+pub fn bind_save_onbeforeunload() {}
 
-pub fn teardown_save() {}
+pub fn unbind_save_onbeforeunload() {}
+
+pub fn delete_save_file() {}
 
 pub fn load(_world: &mut World) -> bool {
     false
 }
+
+pub fn initialize_save_resources() {}

--- a/src/save/save_web.rs
+++ b/src/save/save_web.rs
@@ -121,7 +121,7 @@ thread_local! {
     static ON_BEFORE_UNLOAD: RefCell<Option<Closure<dyn FnMut(BeforeUnloadEvent) -> bool>>> = RefCell::new(None);
 }
 
-pub fn setup_save() {
+pub fn bind_save_onbeforeunload() {
     let window = web_sys::window().expect("window not available");
 
     ON_BEFORE_UNLOAD.with(|opt_closure| {
@@ -139,9 +139,7 @@ pub fn setup_save() {
     });
 }
 
-pub fn teardown_save() {
-    LocalStorage::delete(LOCAL_STORAGE_KEY);
-
+pub fn unbind_save_onbeforeunload() {
     let window = web_sys::window().expect("window not available");
 
     ON_BEFORE_UNLOAD.with(|opt_closure| {
@@ -154,6 +152,18 @@ pub fn teardown_save() {
                 .unwrap();
         }
     });
+}
+
+pub fn delete_save_file() {
+    LocalStorage::delete(LOCAL_STORAGE_KEY);
+}
+
+pub fn initialize_save_resources(mut commands: Commands) {
+    commands.init_resource::<CompressedWebStorageBackend>();
+}
+
+pub fn remove_save_resources(mut commands: Commands) {
+    commands.remove_resource::<CompressedWebStorageBackend>();
 }
 
 pub fn load(world: &mut World) -> bool {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -93,10 +93,10 @@ pub fn register_settings(app_type_registry: ResMut<AppTypeRegistry>) {
     app_type_registry.write().register::<Probabilities>();
 }
 
-pub fn setup_settings(mut commands: Commands) {
+pub fn initialize_settings_resources(mut commands: Commands) {
     commands.init_resource::<Settings>();
 }
 
-pub fn teardown_settings(mut commands: Commands) {
+pub fn remove_settings_resources(mut commands: Commands) {
     commands.remove_resource::<Settings>();
 }

--- a/src/story/ant/mod.rs
+++ b/src/story/ant/mod.rs
@@ -445,7 +445,7 @@ pub fn register_ant(app_type_registry: ResMut<AppTypeRegistry>) {
     app_type_registry.write().register::<Chambering>();
 }
 
-pub fn teardown_ant(ant_model_query: Query<Entity, With<Ant>>, mut commands: Commands) {
+pub fn despawn_ants(ant_model_query: Query<Entity, With<Ant>>, mut commands: Commands) {
     for ant_model_entity in ant_model_query.iter() {
         commands.entity(ant_model_entity).despawn();
     }

--- a/src/story/crater_simulation/mod.rs
+++ b/src/story/crater_simulation/mod.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 
 use crate::{
     app_state::{finalize_startup, AppState},
-    settings::setup_settings,
+    settings::initialize_settings_resources,
 };
 
 use self::{

--- a/src/story/element/mod.rs
+++ b/src/story/element/mod.rs
@@ -71,7 +71,7 @@ pub fn register_element(app_type_registry: ResMut<AppTypeRegistry>) {
     app_type_registry.write().register::<Sand>();
 }
 
-pub fn teardown_element(mut commands: Commands, element_model_query: Query<Entity, With<Element>>) {
+pub fn despawn_elements(mut commands: Commands, element_model_query: Query<Entity, With<Element>>) {
     for element_model_entity in element_model_query.iter() {
         commands.entity(element_model_entity).despawn();
     }

--- a/src/story/nest_rendering/ant/mod.rs
+++ b/src/story/nest_rendering/ant/mod.rs
@@ -647,7 +647,7 @@ pub fn on_ant_wake_up(
     }
 }
 
-pub fn teardown_ant(
+pub fn despawn_ants(
     ant_model_query: Query<Entity, With<Ant>>,
     mut commands: Commands,
     mut model_view_entity_map: ResMut<ModelViewEntityMap>,

--- a/src/story/nest_rendering/common/mod.rs
+++ b/src/story/nest_rendering/common/mod.rs
@@ -111,23 +111,25 @@ pub fn on_update_selected_position(
     transform.translation = world_position;
 }
 
-pub fn setup_common(mut commands: Commands) {
+pub fn initialize_common_resources(mut commands: Commands) {
     commands.init_resource::<ModelViewEntityMap>();
     commands.init_resource::<SelectedEntity>();
     commands.init_resource::<VisibleGrid>();
 }
 
-pub fn teardown_common(
+pub fn remove_common_resources(mut commands: Commands) {
+    commands.remove_resource::<SelectedEntity>();
+    commands.remove_resource::<VisibleGrid>();
+
+    // TODO: removing this causes issues because camera Update runs expecting the resource to exist.
+    //commands.remove_resource::<ModelViewEntityMap>();
+}
+
+pub fn despawn_common_entities(
     selection_sprite_query: Query<Entity, With<SelectionSprite>>,
     mut commands: Commands,
 ) {
     if let Ok(selection_sprite_entity) = selection_sprite_query.get_single() {
         commands.entity(selection_sprite_entity).despawn();
     }
-
-    commands.remove_resource::<SelectedEntity>();
-    commands.remove_resource::<VisibleGrid>();
-
-    // TODO: removing this causes issues because camera Update runs expecting the resource to exist.
-    //commands.remove_resource::<ModelViewEntityMap>();
 }

--- a/src/story/nest_rendering/element/mod.rs
+++ b/src/story/nest_rendering/element/mod.rs
@@ -342,7 +342,7 @@ pub fn get_element_index(exposure: ElementExposure, element: Element) -> usize {
     row_index * 3 + column_index
 }
 
-pub fn teardown_element(
+pub fn despawn_elements(
     mut commands: Commands,
     element_model_query: Query<Entity, With<Element>>,
     element_tilemap_query: Query<Entity, With<ElementTilemap>>,

--- a/src/story/nest_rendering/mod.rs
+++ b/src/story/nest_rendering/mod.rs
@@ -35,7 +35,7 @@ use self::{
 
 use super::{
     grid::VisibleGridState,
-    story_time::{teardown_story_time, StoryPlaybackState, StoryTime, DEFAULT_TICKS_PER_SECOND},
+    story_time::{remove_story_time_resources, StoryPlaybackState, StoryTime, DEFAULT_TICKS_PER_SECOND},
 };
 
 pub struct NestRenderingPlugin;
@@ -136,7 +136,7 @@ impl Plugin for NestRenderingPlugin {
                 teardown_pheromone,
                 teardown_common,
             )
-                .before(teardown_story_time)
+                .before(remove_story_time_resources)
                 .chain(),
         );
 

--- a/src/story/nest_rendering/mod.rs
+++ b/src/story/nest_rendering/mod.rs
@@ -15,21 +15,21 @@ use self::{
         ants_sleep_emote, on_added_ant_dead, on_added_ant_emote, on_ant_ate_food, on_ant_wake_up,
         on_despawn_ant, on_removed_emote, on_spawn_ant, on_tick_emote, on_update_ant_color,
         on_update_ant_inventory, on_update_ant_orientation, on_update_ant_position, rerender_ants,
-        teardown_ant,
+        despawn_ants,
     },
     common::{
-        on_update_selected, on_update_selected_position, setup_common, teardown_common,
-        ModelViewEntityMap,
+        on_update_selected, on_update_selected_position, initialize_common_resources, despawn_common_entities,
+        ModelViewEntityMap, remove_common_resources,
     },
     crater::on_crater_removed_visible_grid,
     element::{
         check_element_sprite_sheet_loaded, on_despawn_element, on_update_element,
-        rerender_elements, start_load_element_sprite_sheet, teardown_element,
+        rerender_elements, start_load_element_sprite_sheet, despawn_elements,
     },
     nest::{on_nest_removed_visible_grid, on_spawn_nest},
     pheromone::{
         on_despawn_pheromone, on_spawn_pheromone, on_update_pheromone_visibility,
-        rerender_pheromones, teardown_pheromone,
+        rerender_pheromones, despawn_pheromones,
     },
 };
 
@@ -56,7 +56,7 @@ impl Plugin for NestRenderingPlugin {
             OnEnter(AppState::FinishSetup),
             (
                 // TODO: Do I need to ensure this runs after other stuff?
-                (setup_common, apply_deferred).chain(),
+                (initialize_common_resources, apply_deferred).chain(),
             )
                 .chain(),
         );
@@ -131,10 +131,11 @@ impl Plugin for NestRenderingPlugin {
         app.add_systems(
             OnEnter(AppState::Cleanup),
             (
-                teardown_ant,
-                teardown_element,
-                teardown_pheromone,
-                teardown_common,
+                despawn_ants,
+                despawn_elements,
+                despawn_pheromones,
+                despawn_common_entities,
+                remove_common_resources,
             )
                 .before(remove_story_time_resources)
                 .chain(),

--- a/src/story/nest_rendering/mod.rs
+++ b/src/story/nest_rendering/mod.rs
@@ -12,30 +12,32 @@ use crate::app_state::AppState;
 
 use self::{
     ant::{
-        ants_sleep_emote, on_added_ant_dead, on_added_ant_emote, on_ant_ate_food, on_ant_wake_up,
-        on_despawn_ant, on_removed_emote, on_spawn_ant, on_tick_emote, on_update_ant_color,
-        on_update_ant_inventory, on_update_ant_orientation, on_update_ant_position, rerender_ants,
-        despawn_ants,
+        ants_sleep_emote, despawn_ants, on_added_ant_dead, on_added_ant_emote, on_ant_ate_food,
+        on_ant_wake_up, on_despawn_ant, on_removed_emote, on_spawn_ant, on_tick_emote,
+        on_update_ant_color, on_update_ant_inventory, on_update_ant_orientation,
+        on_update_ant_position, rerender_ants,
     },
     common::{
-        on_update_selected, on_update_selected_position, initialize_common_resources, despawn_common_entities,
-        ModelViewEntityMap, remove_common_resources,
+        despawn_common_entities, initialize_common_resources, on_update_selected,
+        on_update_selected_position, remove_common_resources, ModelViewEntityMap,
     },
     crater::on_crater_removed_visible_grid,
     element::{
-        check_element_sprite_sheet_loaded, on_despawn_element, on_update_element,
-        rerender_elements, start_load_element_sprite_sheet, despawn_elements,
+        check_element_sprite_sheet_loaded, despawn_elements, on_despawn_element, on_update_element,
+        rerender_elements, start_load_element_sprite_sheet,
     },
     nest::{on_nest_removed_visible_grid, on_spawn_nest},
     pheromone::{
-        on_despawn_pheromone, on_spawn_pheromone, on_update_pheromone_visibility,
-        rerender_pheromones, despawn_pheromones,
+        despawn_pheromones, on_despawn_pheromone, on_spawn_pheromone,
+        on_update_pheromone_visibility, rerender_pheromones,
     },
 };
 
 use super::{
     grid::VisibleGridState,
-    story_time::{remove_story_time_resources, StoryPlaybackState, StoryTime, DEFAULT_TICKS_PER_SECOND},
+    story_time::{
+        remove_story_time_resources, StoryPlaybackState, StoryTime, DEFAULT_TICKS_PER_SECOND,
+    },
 };
 
 pub struct NestRenderingPlugin;
@@ -54,11 +56,7 @@ impl Plugin for NestRenderingPlugin {
 
         app.add_systems(
             OnEnter(AppState::FinishSetup),
-            (
-                // TODO: Do I need to ensure this runs after other stuff?
-                (initialize_common_resources, apply_deferred).chain(),
-            )
-                .chain(),
+            initialize_common_resources,
         );
 
         // Declare all rendering systems within Update. No need to chain systems because all rendering systems

--- a/src/story/nest_rendering/pheromone/mod.rs
+++ b/src/story/nest_rendering/pheromone/mod.rs
@@ -147,7 +147,7 @@ pub fn on_update_pheromone_visibility(
     }
 }
 
-pub fn teardown_pheromone(
+pub fn despawn_pheromones(
     pheromone_model_query: Query<Entity, With<Pheromone>>,
     mut commands: Commands,
     mut model_view_entity_map: ResMut<ModelViewEntityMap>,

--- a/src/story/nest_simulation/background.rs
+++ b/src/story/nest_simulation/background.rs
@@ -142,7 +142,7 @@ pub fn update_sky_background(
 }
 
 // Spawn non-interactive background (sky blue / tunnel brown)
-pub fn setup_background(
+pub fn spawn_background(
     mut commands: Commands,
     nest_query: Query<(&Grid, &Nest)>,
     story_time: Res<StoryTime>,
@@ -252,7 +252,7 @@ pub fn setup_background(
     ));
 }
 
-pub fn teardown_background(
+pub fn despawn_background(
     background_query: Query<Entity, Or<(With<TunnelBackground>, With<SkyBackground>, With<BackgroundTilemap>)>>,
     mut commands: Commands,
 ) {

--- a/src/story/nest_simulation/nest/mod.rs
+++ b/src/story/nest_simulation/nest/mod.rs
@@ -51,7 +51,7 @@ pub fn register_nest(app_type_registry: ResMut<AppTypeRegistry>) {
     app_type_registry.write().register::<AtNest>();
 }
 
-pub fn setup_nest(settings: Res<Settings>, mut commands: Commands) {
+pub fn spawn_nest(settings: Res<Settings>, mut commands: Commands) {
     let surface_level = (settings.nest_height as f32
         - (settings.nest_height as f32 * settings.initial_dirt_percent))
         as isize;
@@ -59,12 +59,14 @@ pub fn setup_nest(settings: Res<Settings>, mut commands: Commands) {
     commands.spawn((Nest::new(surface_level), AtNest));
 }
 
+// TODO: despawn_nest_elements?
+
 /// Creates a new grid of Elements. The grid is densley populated.
 /// Note the intentional omission of calling `commands.spawn_element`. This is because
 /// `spawn_element` writes to the grid cache, which is not yet initialized. The grid cache will
 /// be updated after this function is called. This keeps cache initialization parity between
 /// creating a new world and loading an existing world.
-pub fn setup_nest_elements(
+pub fn spawn_nest_elements(
     nest_query: Query<&Nest>,
     settings: Res<Settings>,
     mut commands: Commands,
@@ -84,7 +86,7 @@ pub fn setup_nest_elements(
     }
 }
 
-pub fn setup_nest_ants(
+pub fn spawn_nest_ants(
     nest_query: Query<&Nest>,
     settings: Res<Settings>,
     mut rng: ResMut<GlobalRng>,
@@ -138,7 +140,7 @@ pub fn setup_nest_ants(
 ///
 /// This is used to speed up most logic because there's a consistent need throughout the application to know what elements are
 /// at or near a given position.
-pub fn setup_nest_grid(
+pub fn insert_nest_grid(
     nest_query: Query<Entity, With<Nest>>,
     element_query: Query<(&mut Position, Entity), (With<Element>, With<AtNest>)>,
     settings: Res<Settings>,
@@ -160,7 +162,7 @@ pub fn setup_nest_grid(
     ));
 }
 
-pub fn teardown_nest(mut commands: Commands, nest_entity_query: Query<Entity, With<Nest>>) {
+pub fn despawn_nest(mut commands: Commands, nest_entity_query: Query<Entity, With<Nest>>) {
     let nest_entity = nest_entity_query.single();
 
     commands.entity(nest_entity).despawn();

--- a/src/story/pheromone/mod.rs
+++ b/src/story/pheromone/mod.rs
@@ -97,7 +97,7 @@ pub fn register_pheromone(app_type_registry: ResMut<AppTypeRegistry>) {
 ///
 /// This isn't super necessary. Performance impact of O(N) lookup on Pheromone is likely to be negligible.
 /// Still, it seemed like a good idea architecturally to have O(1) lookup when Position is known.
-pub fn setup_pheromone(
+pub fn initialize_pheromone_resources(
     pheromone_query: Query<(&mut Position, Entity), With<Pheromone>>,
     mut commands: Commands,
 ) {
@@ -112,16 +112,18 @@ pub fn setup_pheromone(
     commands.insert_resource(PheromoneVisibility(Visibility::Visible));
 }
 
-pub fn teardown_pheromone(
+pub fn remove_pheromone_resources(mut commands: Commands) {
+    commands.remove_resource::<PheromoneMap>();
+    commands.remove_resource::<PheromoneVisibility>();
+}
+
+pub fn despawn_pheromones(
     pheromone_model_query: Query<Entity, With<Pheromone>>,
     mut commands: Commands,
 ) {
     for pheromone_model_entity in pheromone_model_query.iter() {
         commands.entity(pheromone_model_entity).despawn();
     }
-
-    commands.remove_resource::<PheromoneMap>();
-    commands.remove_resource::<PheromoneVisibility>();
 }
 
 pub fn pheromone_duration_tick(

--- a/src/story/pointer/mod.rs
+++ b/src/story/pointer/mod.rs
@@ -43,10 +43,15 @@ pub struct PointerTapState {
     pub position: Option<Vec2>,
 }
 
-pub fn setup_pointer(mut commands: Commands) {
+pub fn initialize_pointer_resources(mut commands: Commands) {
     // Calling init_resource prevents Bevy's automatic event cleanup. Need to do it manually.
     commands.init_resource::<Events<ExternalSimulationEvent>>();
     commands.init_resource::<PointerTapState>();
+}
+
+pub fn remove_pointer_resources(mut commands: Commands) {
+    commands.remove_resource::<Events<ExternalSimulationEvent>>();
+    commands.remove_resource::<PointerTapState>();
 }
 
 const DRAG_THRESHOLD: f32 = 4.0;

--- a/src/story/story_time.rs
+++ b/src/story/story_time.rs
@@ -192,7 +192,6 @@ pub fn register_story_time(app_type_registry: ResMut<AppTypeRegistry>) {
     app_type_registry.write().register::<StoryTime>();
 }
 
-// TODO: awkward timing for this - need to have resources available before calling load (why?)
 pub fn initialize_story_time_resources(mut commands: Commands) {
     commands.init_resource::<StoryRealWorldTime>();
     commands.init_resource::<StoryTime>();
@@ -202,6 +201,16 @@ pub fn initialize_story_time_resources(mut commands: Commands) {
     commands.insert_resource(SimulationTime::new_from_secs(
         1.0 / DEFAULT_TICKS_PER_SECOND as f32,
     ));
+}
+
+pub fn remove_story_time_resources(mut commands: Commands) {
+    commands.remove_resource::<StoryRealWorldTime>();
+    commands.remove_resource::<StoryTime>();
+    commands.remove_resource::<FastForwardingStateInfo>();
+    commands.remove_resource::<TicksPerSecond>();
+
+    // `SimulationTime` is managed by Bevy and can't be removed with panic occurring.
+    commands.insert_resource(SimulationTime::default());
 }
 
 /// On startup, determine how much real-world time has passed since the last time the app ran,
@@ -242,16 +251,6 @@ pub fn setup_story_time(
     }
 
     next_story_playback_state.set(StoryPlaybackState::Playing);
-}
-
-pub fn remove_story_time_resources(mut commands: Commands) {
-    commands.remove_resource::<StoryRealWorldTime>();
-    commands.remove_resource::<StoryTime>();
-    commands.remove_resource::<FastForwardingStateInfo>();
-    commands.remove_resource::<TicksPerSecond>();
-
-    // `SimulationTime` is managed by Bevy and can't be removed with panic occurring.
-    commands.insert_resource(SimulationTime::default());
 }
 
 /// Control whether the app runs at the default or fast tick rate.

--- a/src/story/story_time.rs
+++ b/src/story/story_time.rs
@@ -193,7 +193,7 @@ pub fn register_story_time(app_type_registry: ResMut<AppTypeRegistry>) {
 }
 
 // TODO: awkward timing for this - need to have resources available before calling load (why?)
-pub fn pre_setup_story_time(mut commands: Commands) {
+pub fn initialize_story_time_resources(mut commands: Commands) {
     commands.init_resource::<StoryRealWorldTime>();
     commands.init_resource::<StoryTime>();
     commands.init_resource::<FastForwardingStateInfo>();
@@ -244,7 +244,7 @@ pub fn setup_story_time(
     next_story_playback_state.set(StoryPlaybackState::Playing);
 }
 
-pub fn teardown_story_time(mut commands: Commands) {
+pub fn remove_story_time_resources(mut commands: Commands) {
     commands.remove_resource::<StoryRealWorldTime>();
     commands.remove_resource::<StoryTime>();
     commands.remove_resource::<FastForwardingStateInfo>();


### PR DESCRIPTION
This PR does two things:

1) It renames `setup_` and `teardown_` methods to more specific method names. Originally, I had named them in a generic way in an attempt to convey a lifecycle through their interfaces. I didn't do a great job with this, though. Resource initialization is often a requirement for other systems to be able to run, but it isn't clear to other systems whether calling `setup_` will initialize resources or just spawn something into the world.

2) It moves `CompressedWebStorageBackend` into a newly created `initialize_save_resources` method inside of `save_web`. This fixes the issue where a web-only type was leaking and resulting in broken native builds.


I tested both web and native builds compiled and ran after making these changes.