### PR TITLE
refactor: make element rendering consistent with ant rendering

### DIFF
--- a/src/story/rendering/mod.rs
+++ b/src/story/rendering/mod.rs
@@ -25,7 +25,8 @@ use self::{
             rerender_ants,
         },
         element::{
-            cleanup_elements, on_despawn_element, on_update_element, rerender_elements,
+            cleanup_elements, on_despawn_element, on_spawn_element, on_update_element_exposure,
+            on_update_element_position, rerender_elements,
             sprite_sheet::{check_element_sprite_sheet_loaded, start_load_element_sprite_sheet},
         },
         nest::on_spawn_nest,
@@ -110,7 +111,7 @@ fn build_nest_systems(app: &mut App) {
             on_spawn_nest,
             apply_deferred,
             // Spawn
-            (on_spawn_ant, on_spawn_pheromone),
+            (on_spawn_ant, on_spawn_element, on_spawn_pheromone),
             // Despawn
             // TODO: make these generic
             (on_despawn_ant, on_despawn_element, on_despawn_pheromone),
@@ -133,7 +134,8 @@ fn build_nest_systems(app: &mut App) {
                 ),
                 on_ant_wake_up,
                 on_tick_emote,
-                on_update_element,
+                on_update_element_position,
+                on_update_element_exposure,
                 on_update_pheromone_visibility,
             ),
         )

--- a/src/story/rendering/nest_rendering/element/mod.rs
+++ b/src/story/rendering/nest_rendering/element/mod.rs
@@ -30,6 +30,8 @@ pub fn on_spawn_element(
         None => return,
     };
 
+    // Early exit when Nest isn't visible because there's no view to update.
+    // Exit, rather than skipping system run, to prevent change detection from becoming backlogged.
     let grid = match nest_query.get(visible_grid_entity) {
         Ok(grid) => grid,
         Err(_) => return,
@@ -67,7 +69,9 @@ pub fn on_update_element_position(
         Some(visible_grid_entity) => visible_grid_entity,
         None => return,
     };
-
+    
+    // Early exit when Nest isn't visible because there's no view to update.
+    // Exit, rather than skipping system run, to prevent change detection from becoming backlogged.
     let grid = match nest_query.get(visible_grid_entity) {
         Ok(grid) => grid,
         Err(_) => return,


### PR DESCRIPTION
This is a pretty interesting change, IMO. It runs counter to what I would assume is correct coming from a React background, but seems to be the agreed upon correct approach in ECS. I had discussions with a couple of people in the Bevy Discord: https://discord.com/channels/691052431525675048/1199039790834778246


The changes are:

* Removed on_update_element
* Added on_spawn_element on_update_element_position and on_update_element_exposure
* Use Ref to filter out is_added from the on_update systems. This prevents rendering both via on_spawn_element and on_update_element_* on first add.
* Add strict sanity checks to update systems so they fail if view does not exist. Previously, I relied on a "spawn or insert" pattern.

This is a departure from the previous implementation which was more React-like. The previous approach was much less verbose, but only worked for simple rendering scenarios. This was OK for Element, but made the interface for rendering Element different than the interface for rendering Ant. This was a frequent source of bugs (i.e. `on_spawn_ant` vs `on_update_element` had different scenarios in which they would exhibit buggy behavior)